### PR TITLE
Adapt the package to Python 3

### DIFF
--- a/linguist/metaclasses.py
+++ b/linguist/metaclasses.py
@@ -68,7 +68,7 @@ def field_factory(base_class):
     class TranslationFieldField(TranslationField, base_class):
         pass
 
-    TranslationFieldField.__name__ = b'Translation%s' % base_class.__name__
+    TranslationFieldField.__name__ = 'Translation%s' % base_class.__name__
 
     return TranslationFieldField
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
 from setuptools import setup, find_packages
 
 version = __import__('linguist').__version__
@@ -8,6 +9,10 @@ root = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(root, 'README.rst')) as f:
     README = f.read()
+
+extra = {}
+if sys.version_info >= (3,):
+    extra['use_2to3'] = True
 
 setup(
     name='django-linguist',
@@ -20,6 +25,8 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,
+    use_2to3 = True,
+    convert_2to3_doctests = ['README.rst'],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Internationalization',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,
-    use_2to3 = True,
-    convert_2to3_doctests = ['README.rst'],
+    use_2to3=True,
+    convert_2to3_doctests=['README.rst'],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,6 @@ root = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(root, 'README.rst')) as f:
     README = f.read()
 
-extra = {}
-if sys.version_info >= (3,):
-    extra['use_2to3'] = True
-
 setup(
     name='django-linguist',
     version=version,


### PR DESCRIPTION
Hi,
Trying to use django-linguist in a project I'm building using Django 1.8 on Python 3.4, I noticed that despite what the meta-data of the package indicated it didn't actually run on Python 3.
I did the minimal changes for it to work, using the info on http://pythonhosted.org/setuptools/python3.html
Please check that it doesn't break anything (tests are passing so I guess it doesn't break anything), and consider releasing a new version after including these changes, so that Python 3 users like me can include django-linguist as a dependency.

Thanks!