### PR TITLE
Database settings are loaded from the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ pep8:
 	@(flake8 linguist --ignore=E501,E127,E128,E124)
 
 test:
-	@(py.test -s --cov-report term --cov-config .coveragerc --cov=linguist --color=yes linguist/tests/ -k 'not concurrency')
+	@(honcho run py.test -s --cov-report term --cov-config .coveragerc --cov=linguist --color=yes linguist/tests/ -k 'not concurrency')
 
 serve:
-	@(ENV=example python manage.py migrate && python manage.py runserver)
+	@(honcho run python manage.py migrate && honcho run python manage.py runserver)
 
 delpyc:
 	@(find . -name '*.pyc' -delete)

--- a/README.rst
+++ b/README.rst
@@ -401,6 +401,9 @@ Development
     # Enable virtual environment.
     $ source .venv/bin/activate
 
+    # Copy the environment file
+    $ cp linguist/tests/.env-template .env
+
     # Launch tests
     $ make test
 

--- a/linguist/tests/.env-template
+++ b/linguist/tests/.env-template
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres@localhost:5432/django_linguist

--- a/linguist/tests/settings.py
+++ b/linguist/tests/settings.py
@@ -1,15 +1,10 @@
 # -*- coding: utf-8 -*-
 import django
 
+import dj_database_url
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'django_linguist',
-        'USER': 'postgres',
-        'PASSWORD': '',
-        'HOST': '',
-    }
+    'default': dj_database_url.config(),
 }
 
 SITE_ID = 1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,5 @@ pytest
 pytest-cov
 pytest-django
 exam
+honcho
+dj-database-url


### PR DESCRIPTION
Added this to ease testing.

Adds honcho and dj-database-url for testing. Database url can be defined
in .env file. A template can be found in linguist/tests/.env-template.
